### PR TITLE
Fix diff mode detection

### DIFF
--- a/bin/colordiff
+++ b/bin/colordiff
@@ -22,6 +22,7 @@ _in.pipe(through2(function(chunk, enc, callback) {
   var self = this;
   chunk = chunk.toString();
   var lines = chunk.split(/\r\n|\r|\n/g);
+  if (lines.length) lines = lines.slice(1);
 
   lines.forEach(function(line) {
     if(!_mode) _mode = detect(line);


### PR DESCRIPTION
To detect current diff mode used first line which expected to contain diff output. But the first line contain the spawned diff command. The diff output will be contained starting from the second line. 